### PR TITLE
Some fixes for libdecoration branch.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -20,7 +20,7 @@ pkgbase = glfw-wayland-minecraft
 	depends = wayland
 	depends = libxkbcommon
 	depends = libgl
-	depends = libdecoration-git
+	depends = libdecor
 	provides = glfw=3.4.0
 	conflicts = glfw
 	conflicts = glfw-wayland
@@ -29,10 +29,12 @@ pkgbase = glfw-wayland-minecraft
 	source = 0002-set-O_NONBLOCK-on-repeat-timerfd.patch
 	source = 0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch
 	source = 0004-fix-broken-opengl-screenshots-on-mutter.patch
+	source = 0005-don-t-crash-on-get-scancode-name.patch
 	sha256sums = 70dd8d43efc3b7e5d71e687cb94989f9124d8457b834b221ff9e41c5c8feea9f
-	sha256sums = 599f986b12164b90eb673a012328c2267be7d5eefb2ba40d2047a98f70355c95
+	sha256sums = 7d8ffc69576355e92de269f52c328b75cb7ed3175fc51a3b1ed9729684baeea3
 	sha256sums = 84e1a852a16fa6ca2666dd6833ab621612b7eb3b1b11f806406f8ded1ae51a8e
 	sha256sums = a442f8c7e40fb09775f922b95402108b366114874ee96e370c29e5f8500a02b7
 	sha256sums = 27aea70b07df2d46ac7469c129d28d695eff1ec9492489aa7b2558dd780ebdf0
+	sha256sums = 16a2410511d75f00902ab1869942a80d85261f8390a97be946f82662891351e5
 
 pkgname = glfw-wayland-minecraft

--- a/0001-libdecoration-support.patch
+++ b/0001-libdecoration-support.patch
@@ -56,8 +56,8 @@ index 59ab473c..71917d1e 100644
      list(APPEND glfw_LIBRARIES "${Wayland_LINK_LIBRARIES}")
  
 +    if (GLFW_USE_LIBDECOR)
-+        pkg_check_modules(libdecor REQUIRED libdecor-0.1)
-+        list(APPEND glfw_PKG_DEPS "libdecor-0.1")
++        pkg_check_modules(libdecor REQUIRED libdecor-0)
++        list(APPEND glfw_PKG_DEPS "libdecor-0")
 +        list(APPEND glfw_INCLUDE_DIRS "${libdecor_INCLUDE_DIRS}")
 +        list(APPEND glfw_LIBRARIES "${libdecor_LINK_LIBRARIES}")
 +        add_definitions(-DWITH_DECORATION)

--- a/0005-don-t-crash-on-get-scancode-name.patch
+++ b/0005-don-t-crash-on-get-scancode-name.patch
@@ -1,0 +1,10 @@
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -1378,8 +1378,6 @@
+ const char* _glfwPlatformGetScancodeName(int scancode)
+ {
+     // TODO
+-    _glfwInputError(GLFW_FEATURE_UNIMPLEMENTED,
+-                    "Wayland: Key names not yet implemented");
+     return NULL;
+ }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@ pkgrel=1
 arch=('x86_64')
 url="https://github.com/Admicos/minecraft-wayland"
 license=('custom:ZLIB')
-depends=('wayland' 'libxkbcommon' 'libgl' 'libdecoration-git')
+depends=('wayland' 'libxkbcommon' 'libgl' 'libdecor')
 conflicts=('glfw' 'glfw-wayland')
 provides=("glfw=$pkgver")
 makedepends=('mesa' 'cmake' 'doxygen' 'vulkan-headers' 'vulkan-icd-loader'
@@ -24,12 +24,14 @@ source=("https://github.com/glfw/glfw/archive/${_pkggit}.tar.gz"
         "0001-libdecoration-support.patch"
         "0002-set-O_NONBLOCK-on-repeat-timerfd.patch"
         "0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch"
-        "0004-fix-broken-opengl-screenshots-on-mutter.patch")
+        "0004-fix-broken-opengl-screenshots-on-mutter.patch"
+        "0005-don-t-crash-on-get-scancode-name.patch")
 sha256sums=('70dd8d43efc3b7e5d71e687cb94989f9124d8457b834b221ff9e41c5c8feea9f'
-            '599f986b12164b90eb673a012328c2267be7d5eefb2ba40d2047a98f70355c95'
+            '7d8ffc69576355e92de269f52c328b75cb7ed3175fc51a3b1ed9729684baeea3'
             '84e1a852a16fa6ca2666dd6833ab621612b7eb3b1b11f806406f8ded1ae51a8e'
             'a442f8c7e40fb09775f922b95402108b366114874ee96e370c29e5f8500a02b7'
-            '27aea70b07df2d46ac7469c129d28d695eff1ec9492489aa7b2558dd780ebdf0')
+            '27aea70b07df2d46ac7469c129d28d695eff1ec9492489aa7b2558dd780ebdf0'
+            '16a2410511d75f00902ab1869942a80d85261f8390a97be946f82662891351e5')
 
 prepare() {
   cd "$srcdir/glfw-$_pkggit"


### PR DESCRIPTION
Fix compiling, package name of libdecor and a crash on get-scancode-name.

I can confirm that on Gnome this branch works flawlessly (proper borders, fullscreen and resizing):
![Screenshot from 2021-11-01 02-54-27](https://user-images.githubusercontent.com/1416030/139597543-89cb252e-ec01-4905-a975-9eecfaa14ae1.png)

The only difference from x11 is window decorations, but that's libdecor issue I assume.
