### PR TITLE
Hide mouse cursor ingame on GNOME (libdecoration branch)

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -30,11 +30,13 @@ pkgbase = glfw-wayland-minecraft
 	source = 0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch
 	source = 0004-fix-broken-opengl-screenshots-on-mutter.patch
 	source = 0005-don-t-crash-on-get-scancode-name.patch
+	source = 0006-Fix-cursor-offset-when-shape-changes.patch
 	sha256sums = 7b8c990cfb039110d38c7f5bb21948c402933be3f93f333fe7dcda3deaf72aa4
 	sha256sums = c163b4a0a6496d758bc656203c23151015683754a6b5c2fc4944df7296d6b5af
 	sha256sums = 84e1a852a16fa6ca2666dd6833ab621612b7eb3b1b11f806406f8ded1ae51a8e
 	sha256sums = a442f8c7e40fb09775f922b95402108b366114874ee96e370c29e5f8500a02b7
 	sha256sums = 27aea70b07df2d46ac7469c129d28d695eff1ec9492489aa7b2558dd780ebdf0
 	sha256sums = 16a2410511d75f00902ab1869942a80d85261f8390a97be946f82662891351e5
+	sha256sums = effe5ed88d3bc26cd53a25fbd5732647dc895b315ac8342eddc4678d290ad1aa
 
 pkgname = glfw-wayland-minecraft

--- a/0006-Fix-cursor-offset-when-shape-changes.patch
+++ b/0006-Fix-cursor-offset-when-shape-changes.patch
@@ -1,0 +1,89 @@
+From e7758c506dfcf258566f866c761c1b6bd7d98011 Mon Sep 17 00:00:00 2001
+From: Waris Boonyasiriwat <wboonyasiriwat@teradici.com>
+Date: Wed, 12 May 2021 00:30:14 -0700
+Subject: [PATCH] Wayland: Fix cursor offset when shape changes
+
+The Wayland protocol spec[1] states that set_cursor must be called
+with the serial number of the enter event.  However, GLFW is passing in
+the serial number of the latest received event, which does not meet the
+protocol spec.
+
+[1] https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_pointer
+
+As a result, set_cursor calls were simply ignored by the compositor.
+
+This fix complies with the protocol more closely by specifically caching
+the enter event serial, and using it for all set_cursor calls.
+
+Fixes #1706
+Closes #1899
+---
+ src/wl_init.c     | 3 ++-
+ src/wl_platform.h | 1 +
+ src/wl_window.c   | 6 +++---
+ 4 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/wl_init.c b/src/wl_init.c
+index ac938795c..2c73a7a95 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -118,6 +118,7 @@ static void pointerHandleEnter(void* data,
+
+     window->wl.decorations.focus = focus;
+     _glfw.wl.serial = serial;
++    _glfw.wl.pointerEnterSerial = serial;
+     _glfw.wl.pointerFocus = window;
+
+     window->wl.hovered = GLFW_TRUE;
+@@ -177,7 +178,7 @@ static void setCursor(_GLFWwindow* window, const char* name)
+     buffer = wl_cursor_image_get_buffer(image);
+     if (!buffer)
+         return;
+-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
++    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
+                           surface,
+                           image->hotspot_x / scale,
+                           image->hotspot_y / scale);
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index a24943c92..d6017513f 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -317,6 +317,7 @@ typedef struct _GLFWlibraryWayland
+     const char*                 cursorPreviousName;
+     int                         cursorTimerfd;
+     uint32_t                    serial;
++    uint32_t                    pointerEnterSerial;
+
+     int32_t                     keyboardRepeatRate;
+     int32_t                     keyboardRepeatDelay;
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 618c8e7fc..06cd70847 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -683,7 +683,7 @@ static void setCursorImage(_GLFWwindow* window,
+         cursorWayland->yhot = image->hotspot_y;
+     }
+
+-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
++    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
+                           surface,
+                           cursorWayland->xhot / scale,
+                           cursorWayland->yhot / scale);
+@@ -1455,7 +1455,7 @@ static void lockPointer(_GLFWwindow* window)
+     window->wl.pointerLock.relativePointer = relativePointer;
+     window->wl.pointerLock.lockedPointer = lockedPointer;
+
+-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial,
++    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
+                           NULL, 0, 0);
+ }
+
+@@ -1519,7 +1519,7 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
+     }
+     else if (window->cursorMode == GLFW_CURSOR_HIDDEN)
+     {
+-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.serial, NULL, 0, 0);
++        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial, NULL, 0, 0);
+     }
+ }
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -25,13 +25,15 @@ source=("https://github.com/glfw/glfw/archive/${_pkggit}.tar.gz"
         "0002-set-O_NONBLOCK-on-repeat-timerfd.patch"
         "0003-wayland-don-t-crash-app-on-api-calls-to-window-focus.patch"
         "0004-fix-broken-opengl-screenshots-on-mutter.patch"
-        "0005-don-t-crash-on-get-scancode-name.patch")
+        "0005-don-t-crash-on-get-scancode-name.patch"
+        "0006-Fix-cursor-offset-when-shape-changes.patch")
 sha256sums=('7b8c990cfb039110d38c7f5bb21948c402933be3f93f333fe7dcda3deaf72aa4'
             'c163b4a0a6496d758bc656203c23151015683754a6b5c2fc4944df7296d6b5af'
             '84e1a852a16fa6ca2666dd6833ab621612b7eb3b1b11f806406f8ded1ae51a8e'
             'a442f8c7e40fb09775f922b95402108b366114874ee96e370c29e5f8500a02b7'
             '27aea70b07df2d46ac7469c129d28d695eff1ec9492489aa7b2558dd780ebdf0'
-            '16a2410511d75f00902ab1869942a80d85261f8390a97be946f82662891351e5')
+            '16a2410511d75f00902ab1869942a80d85261f8390a97be946f82662891351e5'
+            'effe5ed88d3bc26cd53a25fbd5732647dc895b315ac8342eddc4678d290ad1aa')
 
 prepare() {
   cd "$srcdir/glfw-$_pkggit"


### PR DESCRIPTION
Surprisingly, this bug was not on libdecor, but on our version of GLFW.

Because the libdecoration branch uses an older snapshot of GLFW's master branch (even with my update today), this patch wasn't included.

This worked on the main branch because this patch seems to have been backported to 3.3.5.

It seems to work on my machine, but I want more people to give it a shot before merging it into the libdecoration branch