### PR TITLE
Add support for Flatpak launchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 !.gitignore
 !README.md
+
+!flatpak-build.sh
+!FLATPAK.md

--- a/FLATPAK.md
+++ b/FLATPAK.md
@@ -2,7 +2,7 @@
 
 ### Note:
 
-Support for `libdecoration` is not present, yet, as the patches are outdated. So if you run GNOME, you'll see white borders, you'll have no minimize, maximize and close buttons and resizing the window will result in lag city, so good luck.
+>Support for `libdecoration` is not present, yet, as the patches are outdated. So if you run GNOME, you'll see white borders, you'll have no minimize, maximize and close buttons and resizing the window will result in lag city, so good luck.
 
 Clone this repository and then run the following commands (ignore everything after the "#"):
 

--- a/FLATPAK.md
+++ b/FLATPAK.md
@@ -1,0 +1,36 @@
+# Flatpak build instructions
+
+### Note:
+
+Support for `libdecoration` is not present, yet, as the patches are outdated. So if you run GNOME, you'll see white borders, you'll have no minimize, maximize and close buttons and resizing the window will result in lag city, so good luck.
+
+Clone this repository and then run the following commands (ignore everything after the "#"):
+
+```bash
+cd minecraft-wayland
+git checkout flatpak                # Select the correct branch
+chmod +x flatpak-build.sh           # Give executable permissions to the script
+./flatpak-build.sh <flatpak-appid>  # Build the library!
+```
+
+Replace `<flatpak-appid>` with the string you use to run the flatpak application. Here are the commands for some of the most common appids:
+
+```bash
+./flatpak-build.sh com.mojang.Minecraft # Official Minecraft launcher
+./flatpak-build.sh org.polymc.PolyMC    # PolyMC launcher
+./flatpak-build.sh io.gdevs.GDLauncher  # GDLauncher
+```
+
+To use this GLFW build instead of the system's, add the following string to the launch commands:
+
+```bash
+-Dorg.lwjgl.glfw.libname=/home/<your-username>/.var/app/<flatpak-appid>/usr/lib/libglfw.so
+```
+
+Replace `<your-username>` and `<flatpak-appid>` with the appropriate values for your use case.
+
+For example, if my username is `mcplayer` and I want use the `PolyMC` launcher, I'll have to add the following string to my Minecraft launch arguments:
+
+```bash
+-Dorg.lwjgl.glfw.libname=/home/mcplayer/.var/app/org.polymc.PolyMC/usr/lib/libglfw.so
+```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ See https://github.com/Admicos/minecraft-wayland/issues/4 for more information.
 
 Patch Gentoo's GLFW package by following the guide at https://github.com/Admicos/minecraft-wayland/issues/6
 
+### Option 5: Build GLFW for Flatpak
+
+Please read [here](./FLATPAK.md).
+
 ## Step 3: There is no step 3
 
 This should be it. Try launching Minecraft now and see if it works.

--- a/flatpak-build.sh
+++ b/flatpak-build.sh
@@ -16,6 +16,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Preparing workspace..."
+cd $appdir
 rm -rf ./tmp
 mkdir tmp && cd tmp
 cwd=$(pwd)
@@ -48,3 +49,5 @@ mkdir build && cd build
 flatpak run --command=sh --devel $appid -c "ECM_DIR=\"$cwd/ecm/share/ECM\" cmake .. -DCMAKE_INSTALL_PREFIX=\"$appdir/usr\" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_SHARED_LIBS=ON -DGLFW_USE_WAYLAND=ON && make install"
 
 echo "Done!"
+cd $appdir
+rm -rf ./tmp

--- a/flatpak-build.sh
+++ b/flatpak-build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+pkggit=62e175ef9fae75335575964c845a302447c012c7
+appid="$1"
+appdir="$HOME/.var/app/$appid"
+
+if [ -z "$appid" ]; then
+    echo "Please provide a Flatpak application ID"
+    exit -1
+fi
+
+flatpak info $appid > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Invalid Flatpak application ID"
+    exit -1
+fi
+
+echo "Preparing workspace..."
+rm -rf ./tmp
+mkdir tmp && cd tmp
+cwd=$(pwd)
+
+echo "Downloading ECM source..."
+git clone https://github.com/KDE/extra-cmake-modules.git
+
+echo "Installing ECM..."
+cd extra-cmake-modules
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX="$cwd/ecm"
+mkdir -p "$cwd/ecm"
+make && make install
+
+echo "Downloading GLFW source..."
+cd "$cwd"
+wget -O glfw.tar.gz https://github.com/glfw/glfw/archive/$pkggit.tar.gz
+
+echo "Uncompressing GLFW source..."
+tar xf glfw.tar.gz
+mv "glfw-$pkggit" "glfw"
+
+echo "Patching GLFW source..."
+cd glfw
+for patch in "$cwd/../00"*.patch; do patch -p1 < "$patch"; done
+
+echo "Building GLFW..."
+mkdir -p "$appdir/usr"
+mkdir build && cd build
+flatpak run --command=sh --devel $appid -c "ECM_DIR=\"$cwd/ecm/share/ECM\" cmake .. -DCMAKE_INSTALL_PREFIX=\"$appdir/usr\" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_SHARED_LIBS=ON -DGLFW_USE_WAYLAND=ON && make install"
+
+echo "Done!"


### PR DESCRIPTION
This PR adds support for building the modified GLFW library for Flatpak based launchers, such as the official Minecraft launcher (com.mojang.Minecraft), PolyMC (org.polymc.PolyMC) and GDLauncher (io.gdevs.GDLauncher).