### PR TITLE
Change MultiMC to Prism Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Because I **REALLY** had nothing better to do with my life.
 
   - Older versions use a version of LWJGL that doesn't work with this patch
 
-- MultiMC (or derivatives) (optional)
+- Prism Launcher (or similar) (optional)
 
   - Other launchers (not the official one) might or might not have similar settings
   - If they don't, you can throw this into your Java arguments, changing the file
@@ -33,9 +33,9 @@ Because I **REALLY** had nothing better to do with my life.
   an unofficial package listed below (until a new GLFW version releases)
   - KDE works on both branches, but with some [minor issues](https://github.com/Admicos/minecraft-wayland/issues/8#issuecomment-997155245)
 
-## Step 1: Setting up MultiMC to use the system GLFW
+## Step 1: Setting up Prism Launcher to use the system GLFW
 
-Go to `Settings` > `Minecraft`, and enable `Use system installation of GLFW`.
+Go to `Settings` > `Minecraft`, `Tweaks` and enable `Use system installation of GLFW`.
 
 If you have a Wayland-compatible version of GLFW installed (`glfw-wayland` on
 Arch) you can try launching the game. It will most likely error out with
@@ -88,7 +88,7 @@ This should be it. Try launching Minecraft now and see if it works.
 ## Bonus: XWayland per instance
 
 If some version of Minecraft doesn't work with the patch enabled, you can
-disable it through MultiMC just for that version by
+disable it through Prism Launcher just for that version by
 
 - Right clicking on your instance
 - Clicking `Edit instance`
@@ -122,3 +122,4 @@ aren't even that old. Here are the proper credits:
 - `christianrauch` on GitHub
 
   - For https://github.com/glfw/glfw/pull/1693
+


### PR DESCRIPTION
Since MultiMC has been largely abandoned by the community due to some security vulnerabilities involving a disrespectful and condescending developer, and the community mostly using Prism Launcher anyway, we may as well just update our references to the launcher in the tutorial.
